### PR TITLE
Set up CRUD routes and Express app.js for ParcTouristique API

### DIFF
--- a/parcTouristique/app.js
+++ b/parcTouristique/app.js
@@ -1,13 +1,22 @@
-// app.js
 const express = require('express');
 const app = express();
+
 app.use(express.json());
 
-// routes
-app.get('/dinosaurs', (req, res) => {
-  res.json([{ id: 1, name: 'T‑Rex2' }]);
-});
+const errorHandler = require('./src/middleware/errorHandler');
 
+
+const dinosaurRoutes = require('./src/routes/dinosaur');
+const incidentRoutes = require('./src/routes/incident');
+const keeperRoutes = require('./src/routes/keeper');
+
+app.use('/dinosaurs', dinosaurRoutes);
+app.use('/incidents', incidentRoutes);
+app.use('/keepers', keeperRoutes);
+
+app.use(errorHandler);
 
 const port = process.env.PORT || 3002;
-app.listen(port, () => console.log(`Parc2 API listening on ${port}`));
+app.listen(port, () => {
+  console.log(`ParcTouristique API en écoute sur le port ${port}`);
+});

--- a/parcTouristique/src/middleware/errorHandler.js
+++ b/parcTouristique/src/middleware/errorHandler.js
@@ -1,6 +1,9 @@
-// server error
+function errorHandler(err, req, res, next) {
+  console.error('Error:', err.stack || err.message);
 
-module.exports = (err, req, res, next) => {
-    console.error(err.stack);
-    res.status(500).json({ error: 'Erreur serveur' });
-};
+  res.status(err.status || 500).json({
+    error: err.message || 'Erreur serveur',
+  });
+}
+
+module.exports = errorHandler;

--- a/parcTouristique/src/routes/dinosaur.js
+++ b/parcTouristique/src/routes/dinosaur.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const router = express.Router();
+const Dinosaur = require('../models/dinosaur');
+
+router.get('/', async (req, res, next) => {
+  try {
+    const dinosaurs = await Dinosaur.find();
+    res.json(dinosaurs);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const newDino = new Dinosaur(req.body);
+    const savedDino = await newDino.save();
+    res.status(201).json(savedDino);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const dino = await Dinosaur.findById(req.params.id);
+    if (!dino) return res.status(404).json({ error: 'Dinosaur not found' });
+    res.json(dino);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const updatedDino = await Dinosaur.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!updatedDino) return res.status(404).json({ error: 'Dinosaur not found' });
+    res.json(updatedDino);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const deletedDino = await Dinosaur.findByIdAndDelete(req.params.id);
+    if (!deletedDino) return res.status(404).json({ error: 'Dinosaur not found' });
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/parcTouristique/src/routes/incident.js
+++ b/parcTouristique/src/routes/incident.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const router = express.Router();
+const Incident = require('../models/incident');
+
+// GET all incidents
+router.get('/', async (req, res, next) => {
+  try {
+    const incidents = await Incident.find().populate('assignedKeeper');
+    res.json(incidents);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST create incident
+router.post('/', async (req, res, next) => {
+  try {
+    const { title, severity, isDone, description, assignedKeeper, date } = req.body;
+    const newIncident = new Incident({ title, severity, isDone, description, assignedKeeper, date });
+    const saved = await newIncident.save();
+    res.status(201).json(saved);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET one by ID
+router.get('/:id', async (req, res, next) => {
+  try {
+    const incident = await Incident.findById(req.params.id).populate('assignedKeeper');
+    if (!incident) return res.status(404).json({ error: 'Incident not found' });
+    res.json(incident);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT update
+router.put('/:id', async (req, res, next) => {
+  try {
+    const updated = await Incident.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!updated) return res.status(404).json({ error: 'Incident not found' });
+    res.json(updated);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const deleted = await Incident.findByIdAndDelete(req.params.id);
+    if (!deleted) return res.status(404).json({ error: 'Incident not found' });
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/parcTouristique/src/routes/keeper.js
+++ b/parcTouristique/src/routes/keeper.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const router = express.Router();
+const Keeper = require('../models/keeper');
+
+// GET all keepers
+router.get('/', async (req, res, next) => {
+  try {
+    const keepers = await Keeper.find();
+    res.json(keepers);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST new keeper
+router.post('/', async (req, res, next) => {
+  try {
+    const { name, age, dateStart, available, sector } = req.body;
+    const newKeeper = new Keeper({ name, age, dateStart, available, sector });
+    const saved = await newKeeper.save();
+    res.status(201).json(saved);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET one keeper by ID
+router.get('/:id', async (req, res, next) => {
+  try {
+    const keeper = await Keeper.findById(req.params.id);
+    if (!keeper) return res.status(404).json({ error: 'Keeper not found' });
+    res.json(keeper);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT update keeper
+router.put('/:id', async (req, res, next) => {
+  try {
+    const updated = await Keeper.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!updated) return res.status(404).json({ error: 'Keeper not found' });
+    res.json(updated);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE keeper
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const deleted = await Keeper.findByIdAndDelete(req.params.id);
+    if (!deleted) return res.status(404).json({ error: 'Keeper not found' });
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
### app.js
- Initialized Express application
- Added JSON parsing middleware
- Mounted routes for dinosaurs, incidents, and keepers
- Integrated centralized error handling middleware
- Server listens on `PORT` (default 3002)
- Ready for MongoDB integration (to be added later)

### `/dinosaurs` routes
- `GET /` → List all dinosaurs
- `GET /:id` → Get one dinosaur by ID
- `POST /` → Create a new dinosaur
- `PUT /:id` → Update dinosaur by ID
- `DELETE /:id` → Delete dinosaur

### `/incidents` routes
- Same CRUD structure
- Includes `.populate('assignedKeeper')` to fetch linked Keeper data

### `/keepers` routes
- Full CRUD support
- Fields: `name`, `age`, `sector`, `available`, etc.

All routes are located under `src/routes/`:
- `src/routes/dinosaur.js`
- `src/routes/incident.js`
- `src/routes/keeper.js`